### PR TITLE
Fix memory leak

### DIFF
--- a/src/main/java/com/on_site/q/Q.java
+++ b/src/main/java/com/on_site/q/Q.java
@@ -644,7 +644,7 @@ public class Q implements Iterable<Element> {
         return ImmutableSet.<Element>builder().add(elements).build();
     }
 
-    private static final LoadingCache<Document, Frizzle> FRIZZLES = CacheBuilder.newBuilder().weakKeys().build(new CacheLoader<Document, Frizzle>() {
+    private static final LoadingCache<Document, Frizzle> FRIZZLES = CacheBuilder.newBuilder().weakKeys().weakValues().build(new CacheLoader<Document, Frizzle>() {
         @Override
         public Frizzle load(Document document) {
             return new Frizzle(document);


### PR DESCRIPTION
The strong Frizzle values held onto the Document, which made the weak keys not really weak.
Making the values weak means that the key or value can be freed once either is no longer referenced.