### PR TITLE
Use softValues to avoid a Frizzle being GCed too early

### DIFF
--- a/src/main/java/com/on_site/q/Q.java
+++ b/src/main/java/com/on_site/q/Q.java
@@ -644,7 +644,7 @@ public class Q implements Iterable<Element> {
         return ImmutableSet.<Element>builder().add(elements).build();
     }
 
-    private static final LoadingCache<Document, Frizzle> FRIZZLES = CacheBuilder.newBuilder().weakKeys().weakValues().build(new CacheLoader<Document, Frizzle>() {
+    private static final LoadingCache<Document, Frizzle> FRIZZLES = CacheBuilder.newBuilder().weakKeys().softValues().build(new CacheLoader<Document, Frizzle>() {
         @Override
         public Frizzle load(Document document) {
             return new Frizzle(document);


### PR DESCRIPTION
Thanks to @cky 